### PR TITLE
Add dill in setup.py, so 'pip install' pulls it in automagically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     url='https://github.com/geophile/marcel',
     packages=setuptools.find_packages('.'),
     scripts=['bin/marcel', 'bin/farcel.py'] ,
+    install_requires=['dill'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
I noticed I had to install dill manually -- this avoids that, but perhaps you haven't done it for some reason?  Anyway, thought I'd send a PR in case it was useful.