### PR TITLE
Fix starting error when no previous version of Marcel

### DIFF
--- a/marcel/migration/migration.py
+++ b/marcel/migration/migration.py
@@ -44,6 +44,6 @@ def migrate():
 
     locations = marcel.locations.Locations()
     iv = installed_version(locations)
-    if iv and iv < '0.24':
+    if iv != PREMIGRATION and iv < '0.24':
         marcel.migration.migration024.migrate(locations)
-    update_version_file()
+        update_version_file()

--- a/marcel/migration/migration.py
+++ b/marcel/migration/migration.py
@@ -44,6 +44,6 @@ def migrate():
 
     locations = marcel.locations.Locations()
     iv = installed_version(locations)
-    if iv < '0.24':
+    if iv and iv < '0.24':
         marcel.migration.migration024.migrate(locations)
     update_version_file()


### PR DESCRIPTION
Fresh install of Marcel fails to start because it tries to migrate an inexistent previous profile. Added a simple check to avoid this behavior.

Error is:
```
  File "/home/christian/.pyenv/versions/3.12.2/lib/python3.12/shutil.py", line 886, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/home/christian/.config/marcel/startup.py' -> '/home/christian/.config/marcel/__DEFAULT_WORKSPACE__/startup.py'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/christian/venvs/marcel/lib/python3.12/site-packages/marcel/main.py", line 388, in <module>
    main()
  File "/home/christian/venvs/marcel/lib/python3.12/site-packages/marcel/main.py", line 376, in main
    marcel.migration.migration.migrate()
  File "/home/christian/venvs/marcel/lib/python3.12/site-packages/marcel/migration/migration.py", line 48, in migrate
    marcel.migration.migration024.migrate(locations)
  File "/home/christian/venvs/marcel/lib/python3.12/site-packages/marcel/migration/migration024.py", line 83, in migrate
    shutil.move(config_dir_path_old / 'startup.py', config_dir_path)
  File "/home/christian/.pyenv/versions/3.12.2/lib/python3.12/shutil.py", line 906, in move
    copy_function(src, real_dst)
  File "/home/christian/.pyenv/versions/3.12.2/lib/python3.12/shutil.py", line 475, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/home/christian/.pyenv/versions/3.12.2/lib/python3.12/shutil.py", line 260, in copyfile
    with open(src, 'rb') as fsrc:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/christian/.config/marcel/startup.py'
```