### PR TITLE
Fix "SyntaxWarning: invalid escape sequence" warnings

### DIFF
--- a/marcel/doc/help_color.py
+++ b/marcel/doc/help_color.py
@@ -52,12 +52,12 @@ COLOR_SCHEME.file_file = COLOR_WHITE_BOLD
 COLOR_SCHEME.file_dir = Color(0, 2, 3, BOLD)
 COLOR_SCHEME.file_link = Color(4, 2, 0, BOLD)
 COLOR_SCHEME.file_executable = Color(0, 4, 0, BOLD)
-COLOR_SCHEME.file_extension =  \{'.jpg': COLOR_IMAGE_HIGHLIGHT,
+COLOR_SCHEME.file_extension =  \\{'.jpg': COLOR_IMAGE_HIGHLIGHT,
                                 '.jpeg': COLOR_IMAGE_HIGHLIGHT,
                                 '.png': COLOR_IMAGE_HIGHLIGHT,
                                 '.mov': COLOR_IMAGE_HIGHLIGHT,
                                 '.avi': COLOR_IMAGE_HIGHLIGHT,
-                                '.gif': COLOR_IMAGE_HIGHLIGHT\}
+                                '.gif': COLOR_IMAGE_HIGHLIGHT\\}
 COLOR_SCHEME.error = Color(5, 5, 0)
 COLOR_SCHEME.process_pid = Color(0, 2, 4, BOLD)
 COLOR_SCHEME.process_command = Color(3, 2, 0, BOLD)

--- a/marcel/doc/help_operator.py
+++ b/marcel/doc/help_operator.py
@@ -78,9 +78,9 @@ The {n:write} command can be made explicit to add formatting and redirection opt
 For example, to format the above output differently:
 
 {p,wrap=F,indent=4}
-ls -f | map (f: (f.name, f.size)) | out '\{\}: \{\}'
+ls -f | map (f: (f.name, f.size)) | out '\\{\\}: \\{\\}'
 
-The standard Python formatting string, '\{\}: \{\}' produces this output:
+The standard Python formatting string, '\\{\\}: \\{\\}' produces this output:
 
 {p,wrap=F,indent=4}
 10-console-messages.conf: 77

--- a/marcel/version.py
+++ b/marcel/version.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Marcel.  If not, see <https://www.gnu.org/licenses/>.
 
-VERSION = '0.25.0'
+VERSION = '0.26.0'

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -268,7 +268,7 @@ def test_red():
              expected_out=[1])
     TEST.run('gen 20 1 | select (x: x in (3, 7, 15)) | red &',
              expected_out=[3])
-    TEST.run('gen 75 | select (x: x in (18, 36, 73)) | red \|',
+    TEST.run('gen 75 | select (x: x in (18, 36, 73)) | red \\|',
              expected_out=[127])
     TEST.run('gen 3 | map (x: x == 1) | red and',
              expected_out=[False])


### PR DESCRIPTION
Hello, fixed a few warnings emitted when using Python 3.12.

From: https://docs.python.org/3.14/whatsnew/3.12.html#other-language-changes

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3.14/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3.14/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3.14/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3.14/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3.14/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)

```
$ python --version
Python 3.12.3
```

```
$ python -m compileall -f -q .
./marcel/doc/help_color.py:16: SyntaxWarning: invalid escape sequence '\{'
  HELP = '''
./marcel/doc/help_operator.py:16: SyntaxWarning: invalid escape sequence '\{'
  HELP = '''
./test/test_ops.py:271: SyntaxWarning: invalid escape sequence '\|'
  TEST.run('gen 75 | select (x: x in (18, 36, 73)) | red \|',
```